### PR TITLE
SMTP and SMTP_SSL can now be used as asynchronous context manager.

### DIFF
--- a/smtplibaio.py
+++ b/smtplibaio.py
@@ -299,6 +299,21 @@ class SMTP:
         finally:
             self.close()
 
+    @asyncio.coroutine
+    def __aenter__(self):
+        return self
+
+    @asyncio.coroutine
+    def __aexit__(self, *args):
+        try:
+            code, message = yield from self.docmd("QUIT")
+            if code != 221:
+                raise SMTPResponseException(code, message)
+        except SMTPServerDisconnected:
+            pass
+        finally:
+            self.close()
+
     def set_debuglevel(self, debuglevel):
         """Set the debug output level.
 


### PR DESCRIPTION
Allows one to write :

```
with smtplibaio.SMTP_SSL() if use_ssl else smtplibaio.SMTP() as server:
    code, _ = await server.connect(mail_server)
    if code == 220:
        await server.login(user, pwd)
        await server.sendmail(from_mail, to_mail, msg.as_string())
```

Note: asynchronous context manager are only available starting with Python 3.5.
See PEP 0492 for further details (https://www.python.org/dev/peps/pep-0492/#asynchronous-context-managers-and-async-with
