### PR TITLE
Fixed documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Example
 
 ```Python
 import asyncio
-from libsmtpaio import SMTP_SSL
 
-@asyncio.coroutine
-def send(from_email, to_email, msg)
+from smtplibaio import SMTP_SSL
+
+async def send(from_email, to_email, msg)
     server = SMTP_SSL()
-    code, msg = yield from server.connect(mail_server)
+    code, _ = await server.connect(mail_server)
     assert code == 220, "connect failed"
     try:
-        yield from server.login(mailbox_name, mailbox_password)
-        yield from server.sendmail(from_email, to_email, msg.as_string())
+        await server.login(mailbox_name, mailbox_password)
+        await server.sendmail(from_email, to_email, msg.as_string())
     finally:
-        yield from server.quit()
+        await server.quit()
 ```

--- a/smtplibaio.py
+++ b/smtplibaio.py
@@ -13,16 +13,15 @@ and MAIL commands!
 
 Example:
 
-@asyncio.coroutine
-def send(from_email, to_email, msg)
+async def send(from_email, to_email, msg)
     server = SMTP_SSL()
-    code, msg = yield from server.connect(mail_server)
+    code, _ = await server.connect(mail_server)
     assert code == 220, "connect failed"
     try:
-        yield from server.login(mailbox_name, mailbox_password)
-        yield from server.sendmail(from_email, to_email, msg.as_string())
+        await server.login(mailbox_name, mailbox_password)
+        await server.sendmail(from_email, to_email, msg.as_string())
     finally:
-        yield from server.quit()
+        await server.quit()
 '''
 
 # Author: The Dragon De Monsyne <dragondm@integral.org>


### PR DESCRIPTION
- Removed the @asyncio.coroutine decorator in favor of `async` keyword.
- Replaced `yield from` statements in favor of `await` statements.

More important:
- Example in README file was importing "libsmtpaio" instead of "smtplibaio".
- The `msg` argument of the `send` function given as an example was overwritten in the function itself. As a consequence, if you'd simply copy/paste the given example, the resulting e-mail would never contain the passed `msg`, which is...well..unexpected.
